### PR TITLE
add "syslog_drain" to "requires" section in catalog

### DIFF
--- a/src/main/java/org/cloudfoundry/community/servicebroker/s3/config/BrokerConfiguration.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/s3/config/BrokerConfiguration.java
@@ -83,7 +83,7 @@ public class BrokerConfiguration {
     public Catalog catalog() throws JsonParseException, JsonMappingException, IOException {
         ServiceDefinition serviceDefinition = new ServiceDefinition("s3", "amazon-s3",
                 "Amazon S3 is storage for the Internet.", true, getPlans(), getTags(), getServiceDefinitionMetadata(),
-                null, null);
+                Arrays.asList("syslog_drain"), null);
         return new Catalog(Arrays.asList(serviceDefinition));
     }
 


### PR DESCRIPTION
 fixes the following error when binding an s3 service to an application:

 "Server error, status code: 502, error code: 10001, message: The service is
 attempting to stream logs from your application, but is not registered as a
 logging service. Please contact the service provider."
