### PR TITLE
pom.xml: force joda-time to version 2.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,12 @@
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk</artifactId>
-			<version>1.9.39</version>
+			<version>1.9.40</version>
+		</dependency>
+		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+			<version>2.8.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>


### PR DESCRIPTION
Which is required when running on JDK 1.8u60 and newer.

Tests are failing with:

> com.amazonaws.services.s3.model.AmazonS3Exception: AWS authentication
> requires a valid Date or x-amz-date header

Reference: https://github.com/aws/aws-sdk-java/commit/30b3d16
