### PR TITLE
Split plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,20 +43,7 @@ cf create-service-broker s3-cf-service-broker user mysecret http://s3-cf-service
 
 Add service broker to Cloud Foundry Marketplace:
 ```
-cf enable-service-access amazon-s3 -p "Basic S3 Plan" -o ORG
-```
-
-## Testing
-
-Export AWS credentials environment variables:
-```
-export AWS_ACCESS_KEY="YOUR_AWS_ACCESS_KEY"
-export AWS_SECRET_KEY="YOUR_AWS_SECRET_KEY"
-```
-
-and execute tests with maven:
-```
-mvn test
+cf enable-service-access amazon-s3 -o ORG
 ```
 
 ## Using the services in your application
@@ -86,6 +73,21 @@ The default password configured is "password"
 
 ## Creation and Naming of AWS Resources
 
+### User for Broker
+
+An AWS user must be created for the broker. The user's accessKey and secretKey must be provided using the environments variables `AWS_ACCESS_KEY` and `AWS_SECRET_KEY`.
+
+Resource          | Environment Variable | Default
+------------------|----------------------|-------------
+Broker Access Key | AWS_ACCESS_KEY       | - (required)
+Broker Secret Key | AWS_SECRET_KEY       | - (required)
+
+An example user policy for the broker user is provided in [broker-user-iam-policy.json](src/main/resources/broker-user-iam-policy.json). If desired, you can further limit user and group resources in this policy based on prefixes defined above.
+
+Note: The S3 policies could be more limited based on what is actually used.
+
+### Basic Plan
+
 A service provisioning call will create an S3 bucket, an IAM group, and an IAM Policy to provide access controls on the bucket. A binding call will create an IAM user, generate access keys, and add it to the bucket's group. Unbinding and deprovisioning calls will delete all resources created.
 
 The following names are used and can be customized with a prefix:
@@ -104,20 +106,11 @@ Resource    | Custom Path Environment Variable  | Default Path
 IAM User    | USER_PATH                         | /cloud-foundry/s3/
 IAM Group   | GROUP_PATH                        | /cloud-foundry/s3/
 
+#### Bucket Policy
 
-## User for Broker
+The group policy applied to all buckets created is provided in [default-bucket-policy.json](src/main/resources/default-bucket-policy.json).
 
-An AWS user must be created for the broker. The user's accessKey and secretKey must be provided using the environments variables `AWS_ACCESS_KEY` and `AWS_SECRET_KEY`.
-
-An example user policy for the broker user is provided in [broker-user-iam-policy.json](https://github.com/cloudfoundry-community/s3-cf-service-broker/blob/master/src/main/resources/broker-user-iam-policy.json). If desired, you can further limit user and group resources in this policy based on prefixes defined above.
-
-Note: The S3 policies could be more limited based on what is actually used.
-
-## Bucket Policy
-
-The group policy applied to all buckets created is provided in [default-bucket-policy.json](https://github.com/cloudfoundry-community/s3-cf-service-broker/blob/master/src/main/resources/default-bucket-policy.json).
-
-## Bucket Tagging
+#### Bucket Tagging
 
 All buckets are tagged with the following values:
 * serviceInstanceId
@@ -131,3 +124,16 @@ The ability to apply additional custom tags is in the works.
 ## Registering a Broker with the Cloud Controller
 
 See [Managing Service Brokers](http://docs.cloudfoundry.org/services/managing-service-brokers.html).
+
+## Testing
+
+Export AWS credentials environment variables:
+```
+export AWS_ACCESS_KEY="YOUR_AWS_ACCESS_KEY"
+export AWS_SECRET_KEY="YOUR_AWS_SECRET_KEY"
+```
+
+and execute tests with maven:
+```
+mvn test
+```

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A Cloud Foundry Service Broker for Amazon S3 built using the [spring-boot-cf-service-broker](https://github.com/cloudfoundry-community/spring-boot-cf-service-broker).
 
-The broker currently publishes a single service and plan for provisioning S3 buckets. 
+The broker currently publishes a single service and plan for provisioning S3 buckets.
 
-## Design 
+## Design
 
 The broker uses meta data in S3 and naming conventions to maintain the state of the services it is brokering. It does not maintain an internal database so it has no dependencies besides S3.
 
@@ -84,13 +84,13 @@ For Java applications, you may consider using [Spring Cloud](https://github.com/
 
 The default password configured is "password"
 
-## Creation and Naming of AWS Resources 
+## Creation and Naming of AWS Resources
 
 A service provisioning call will create an S3 bucket, an IAM group, and an IAM Policy to provide access controls on the bucket. A binding call will create an IAM user, generate access keys, and add it to the bucket's group. Unbinding and deprovisioning calls will delete all resources created.
 
 The following names are used and can be customized with a prefix:
 
-Resource         | Name is based on     | Custom Prefix Environment Variable  | Default Prefix    | Example Name  
+Resource         | Name is based on     | Custom Prefix Environment Variable  | Default Prefix    | Example Name
 -----------------|----------------------|-------------------------------------|-------------------|---------------
 S3 Buckets       | service instance ID  | BUCKET_NAME_PREFIX                  | cloud-foundry-    | cloud-foundry-2eac2d52-bfc9-4d0f-af28-c02187689d72
 IAM Group Names  | service instance ID  | GROUP_NAME_PREFIX                   | cloud-foundry-s3- | cloud-foundry-s3-2eac2d52-bfc9-4d0f-af28-c02187689d72
@@ -99,10 +99,10 @@ IAM User Names   | binding ID           | USER_NAME_PREFIX                    | 
 
 Also the following paths are used for IAM resources and can be customized with a prefix:
 
-Resource    | Custom Path Environment Variable  | Default Path 
+Resource    | Custom Path Environment Variable  | Default Path
 ------------|-----------------------------------|---------------
-IAM User    | USER_PATH                         | /cloud-foundry/s3/ 
-IAM Group   | GROUP_PATH                        | /cloud-foundry/s3/ 
+IAM User    | USER_PATH                         | /cloud-foundry/s3/
+IAM Group   | GROUP_PATH                        | /cloud-foundry/s3/
 
 
 ## User for Broker
@@ -111,7 +111,7 @@ An AWS user must be created for the broker. The user's accessKey and secretKey m
 
 An example user policy for the broker user is provided in [broker-user-iam-policy.json](https://github.com/davidehringer/s3-cf-service-broker/blob/master/src/main/resources/broker-user-iam-policy.json). If desired, you can further limit user and group resources in this policy based on prefixes defined above.
 
-Note: The S3 policies could be more limited based on what is actually used. 
+Note: The S3 policies could be more limited based on what is actually used.
 
 ## Bucket Policy
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The credentials provided in a bind call have the following format:
 
 ### Java Applications - Spring Cloud
 
-For Java applications, you may consider using [Spring Cloud](https://github.com/spring-projects/spring-cloud) and the [spring-cloud-s3-service-connector](https://github.com/davidehringer/spring-cloud-s3-service-connector).
+For Java applications, you may consider using [Spring Cloud](https://github.com/spring-projects/spring-cloud) and the [spring-cloud-s3-service-connector](https://github.com/cloudfoundry-community/spring-cloud-s3-service-connector).
 
 ## Broker Security
 
@@ -109,13 +109,13 @@ IAM Group   | GROUP_PATH                        | /cloud-foundry/s3/
 
 An AWS user must be created for the broker. The user's accessKey and secretKey must be provided using the environments variables `AWS_ACCESS_KEY` and `AWS_SECRET_KEY`.
 
-An example user policy for the broker user is provided in [broker-user-iam-policy.json](https://github.com/davidehringer/s3-cf-service-broker/blob/master/src/main/resources/broker-user-iam-policy.json). If desired, you can further limit user and group resources in this policy based on prefixes defined above.
+An example user policy for the broker user is provided in [broker-user-iam-policy.json](https://github.com/cloudfoundry-community/s3-cf-service-broker/blob/master/src/main/resources/broker-user-iam-policy.json). If desired, you can further limit user and group resources in this policy based on prefixes defined above.
 
 Note: The S3 policies could be more limited based on what is actually used.
 
 ## Bucket Policy
 
-The group policy applied to all buckets created is provided in [default-bucket-policy.json](https://github.com/davidehringer/s3-cf-service-broker/blob/master/src/main/resources/default-bucket-policy.json).
+The group policy applied to all buckets created is provided in [default-bucket-policy.json](https://github.com/cloudfoundry-community/s3-cf-service-broker/blob/master/src/main/resources/default-bucket-policy.json).
 
 ## Bucket Tagging
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,12 @@
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk</artifactId>
-			<version>1.9.39</version>
+			<version>1.9.40</version>
+		</dependency>
+		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+			<version>2.8.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/src/main/java/org/cloudfoundry/community/servicebroker/s3/config/BrokerConfiguration.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/s3/config/BrokerConfiguration.java
@@ -17,16 +17,14 @@ package org.cloudfoundry.community.servicebroker.s3.config;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.cloudfoundry.community.servicebroker.config.BrokerApiVersionConfig;
 import org.cloudfoundry.community.servicebroker.model.Catalog;
 import org.cloudfoundry.community.servicebroker.model.Plan;
 import org.cloudfoundry.community.servicebroker.model.ServiceDefinition;
-import org.cloudfoundry.community.servicebroker.s3.service.BucketGroupPolicy;
+import org.cloudfoundry.community.servicebroker.s3.plan.basic.BasicPlan;
+import org.cloudfoundry.community.servicebroker.s3.policy.BucketGroupPolicy;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -40,8 +38,6 @@ import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClient;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 
@@ -51,14 +47,15 @@ import com.google.common.io.Resources;
 @Configuration
 @ComponentScan(basePackages = "org.cloudfoundry.community.servicebroker", excludeFilters = { @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = BrokerApiVersionConfig.class) })
 public class BrokerConfiguration {
-    
+
     @Value("${AWS_ACCESS_KEY}")
     private String accessKey;
     
     @Value("${AWS_SECRET_KEY}")
     private String secretKey;
 
-    private AWSCredentials awsCredentials() {
+    @Bean
+    public AWSCredentials awsCredentials() {
         return new BasicAWSCredentials(accessKey, secretKey);
     }
 
@@ -80,7 +77,7 @@ public class BrokerConfiguration {
     }
 
     @Bean
-    public Catalog catalog() throws JsonParseException, JsonMappingException, IOException {
+    public Catalog catalog() throws IOException {
         ServiceDefinition serviceDefinition = new ServiceDefinition("s3", "amazon-s3",
                 "Amazon S3 is storage for the Internet.", true, getPlans(), getTags(), getServiceDefinitionMetadata(),
                 Arrays.asList("syslog_drain"), null);
@@ -103,18 +100,8 @@ public class BrokerConfiguration {
     }
 
     private List<Plan> getPlans() {
-        Plan basic = new Plan("s3-basic-plan", "Basic S3 Plan",
-                "An S3 plan providing a single bucket with unlimited storage.", getBasicPlanMetadata());
-        return Arrays.asList(basic);
-    }
-
-    private Map<String, Object> getBasicPlanMetadata() {
-        Map<String, Object> planMetadata = new HashMap<String, Object>();
-        planMetadata.put("bullets", getBasicPlanBullets());
-        return planMetadata;
-    }
-
-    private List<String> getBasicPlanBullets() {
-        return Arrays.asList("Single S3 bucket", "Unlimited storage", "Unlimited number of objects");
+        List<Plan> myPlans = new ArrayList<Plan>();
+        myPlans.add(BasicPlan.getPlan());
+        return myPlans;
     }
 }

--- a/src/main/java/org/cloudfoundry/community/servicebroker/s3/plan/Plan.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/s3/plan/Plan.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cloudfoundry.community.servicebroker.s3.plan;
+
+import org.cloudfoundry.community.servicebroker.exception.ServiceBrokerException;
+import org.cloudfoundry.community.servicebroker.model.ServiceDefinition;
+import org.cloudfoundry.community.servicebroker.model.ServiceInstance;
+import org.cloudfoundry.community.servicebroker.model.ServiceInstanceBinding;
+
+import java.util.List;
+
+public interface Plan {
+    // static org.cloudfoundry.community.servicebroker.model.Plan getPlan() should also be present, but is static.
+
+    ServiceInstance createServiceInstance(ServiceDefinition service, String serviceInstanceId, String planId,
+                                          String organizationGuid, String spaceGuid);
+
+    ServiceInstance deleteServiceInstance(String id);
+
+    ServiceInstanceBinding createServiceInstanceBinding(String bindingId, ServiceInstance serviceInstance,
+                                                               String serviceId, String planId, String appGuid);
+
+    ServiceInstanceBinding deleteServiceInstanceBinding(String bindingId, ServiceInstance serviceInstance,
+                                                               String serviceId, String planId) throws ServiceBrokerException;
+
+    List<ServiceInstance> getAllServiceInstances();
+
+    ServiceInstance getServiceInstance(String id);
+}

--- a/src/main/java/org/cloudfoundry/community/servicebroker/s3/plan/basic/BasicPlan.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/s3/plan/basic/BasicPlan.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cloudfoundry.community.servicebroker.s3.plan.basic;
+
+import com.amazonaws.services.identitymanagement.model.AccessKey;
+import com.amazonaws.services.identitymanagement.model.User;
+import com.amazonaws.services.s3.model.Bucket;
+import org.cloudfoundry.community.servicebroker.exception.ServiceBrokerException;
+import org.cloudfoundry.community.servicebroker.model.ServiceDefinition;
+import org.cloudfoundry.community.servicebroker.model.ServiceInstance;
+import org.cloudfoundry.community.servicebroker.model.ServiceInstanceBinding;
+import org.cloudfoundry.community.servicebroker.s3.plan.Plan;
+import org.cloudfoundry.community.servicebroker.s3.service.Iam;
+import org.cloudfoundry.community.servicebroker.s3.service.S3;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class BasicPlan implements Plan {
+    public static final String PLAN_ID = "s3-basic-plan";
+
+    private final Iam iam;
+    private final S3 s3;
+
+    @Autowired
+    public BasicPlan(Iam iam, S3 s3) {
+        this.iam = iam;
+        this.s3 = s3;
+    }
+
+    public static org.cloudfoundry.community.servicebroker.model.Plan getPlan() {
+        return new org.cloudfoundry.community.servicebroker.model.Plan(PLAN_ID, "basic", "An S3 plan providing a single bucket with unlimited storage.",
+                getPlanMetadata());
+    }
+
+    private static Map<String, Object> getPlanMetadata() {
+        Map<String, Object> planMetadata = new HashMap<String, Object>();
+        planMetadata.put("bullets", getPlanBullets());
+        return planMetadata;
+    }
+
+    private static List<String> getPlanBullets() {
+        return Arrays.asList("Single S3 bucket", "Unlimited storage", "Unlimited number of objects");
+    }
+
+    public ServiceInstance createServiceInstance(ServiceDefinition service, String serviceInstanceId, String planId,
+                                                 String organizationGuid, String spaceGuid) {
+        Bucket bucket = s3.createBucketForInstance(serviceInstanceId, service, planId, organizationGuid, spaceGuid);
+        iam.createGroupForBucket(serviceInstanceId, bucket.getName());
+        iam.applyGroupPolicyForBucket(serviceInstanceId, bucket.getName());
+        return new ServiceInstance(serviceInstanceId, service.getId(), planId, organizationGuid, spaceGuid, null);
+    }
+
+    public ServiceInstance deleteServiceInstance(String id) {
+        ServiceInstance instance = s3.findServiceInstance(id);
+        // TODO we need to make these deletes idempotent so we can handle retries on error
+        iam.deleteGroupPolicy(id);
+        iam.deleteGroupForInstance(id);
+        s3.emptyBucket(id);
+        s3.deleteBucket(id);
+        return instance;
+    }
+
+    public ServiceInstanceBinding createServiceInstanceBinding(String bindingId, ServiceInstance serviceInstance,
+                                                               String serviceId, String planId, String appGuid) {
+        User user = iam.createUserForBinding(bindingId);
+        AccessKey accessKey = iam.createAccessKey(user);
+        // TODO create password and add to credentials
+        iam.addUserToGroup(user, iam.getGroupNameForInstance(serviceInstance.getId()));
+
+        Map<String, Object> credentials = new HashMap<String, Object>();
+        credentials.put("bucket", s3.getBucketNameForInstance(serviceInstance.getId()));
+        credentials.put("username", user.getUserName());
+        credentials.put("access_key_id", accessKey.getAccessKeyId());
+        credentials.put("secret_access_key", accessKey.getSecretAccessKey());
+        return new ServiceInstanceBinding(bindingId, serviceInstance.getId(), credentials, null, appGuid);
+    }
+
+    public ServiceInstanceBinding deleteServiceInstanceBinding(String bindingId, ServiceInstance serviceInstance,
+                                                               String serviceId, String planId) throws ServiceBrokerException {
+        // TODO make operations idempotent so we can handle retries on error
+        iam.removeUserFromGroup(bindingId, serviceInstance.getId());
+        iam.deleteUserAccessKeys(bindingId);
+        iam.deleteUserForBinding(bindingId);
+        return new ServiceInstanceBinding(bindingId, serviceInstance.getId(), null, null, null);
+    }
+
+    public List<ServiceInstance> getAllServiceInstances() {
+        return s3.getAllServiceInstances();
+    }
+
+    public ServiceInstance getServiceInstance(String id) {
+        return s3.findServiceInstance(id);
+    }
+}

--- a/src/main/java/org/cloudfoundry/community/servicebroker/s3/plan/basic/BasicPlanIam.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/s3/plan/basic/BasicPlanIam.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cloudfoundry.community.servicebroker.s3.plan.basic;
+
+import org.cloudfoundry.community.servicebroker.s3.policy.BucketGroupPolicy;
+import org.cloudfoundry.community.servicebroker.s3.service.Iam;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
+import com.amazonaws.services.identitymanagement.model.Group;
+import com.amazonaws.services.identitymanagement.model.User;
+
+/**
+ * @author David Ehringer
+ */
+@Component
+public class BasicPlanIam extends Iam {
+    private static final Logger logger = LoggerFactory.getLogger(BasicPlanIam.class);
+
+    @Autowired
+    public BasicPlanIam(AmazonIdentityManagement iam, BucketGroupPolicy bucketGroupPolicy,
+                        @Value("${GROUP_PATH:/cloud-foundry/s3/}") String groupPath,
+                        @Value("${GROUP_NAME_PREFIX:cloud-foundry-s3-}") String groupNamePrefix,
+                        @Value("${POLICY_NAME_PREFIX:cloud-foundry-s3-}") String policyNamePrefix,
+                        @Value("${USER_PATH:/cloud-foundry/s3/}") String userPath,
+                        @Value("${USER_NAME_PREFIX:cloud-foundry-s3-}") String userNamePrefix) {
+        super(iam, bucketGroupPolicy, groupPath, groupNamePrefix, policyNamePrefix, userPath, userNamePrefix);
+    }
+
+    public Group createGroupForInstance(String instanceId, String bucketName) {
+        String groupName = getGroupNameForInstance(instanceId);
+        logger.info("Creating group '{}' for bucket '{}'", groupName, bucketName);
+        return createGroup(groupName);
+    }
+
+    public void applyGroupPolicyForInstance(String instanceId, String bucketName) {
+        String groupName = getGroupNameForInstance(instanceId);
+        String policyName = getPolicyNameForInstance(instanceId);
+        applyGroupPolicy(groupName, policyName, bucketName);
+    }
+
+    public void deleteGroupPolicyForInstance(String instanceId) {
+        String groupName = getGroupNameForInstance(instanceId);
+        String policyName = getPolicyNameForInstance(instanceId);
+        deleteGroupPolicy(groupName, policyName);
+    }
+
+    public void deleteGroupForInstance(String instanceId) {
+        String groupName = getGroupNameForInstance(instanceId);
+        logger.info("Deleting group '{}' for instance '{}'", groupName, instanceId);
+        deleteGroup(groupName);
+    }
+
+    public String getGroupNameForInstance(String instanceId) {
+        return getGroupNamePrefix() + instanceId;
+    }
+
+    private String getPolicyNameForInstance(String instanceId) {
+        return getPolicyNamePrefix() + instanceId;
+    }
+
+    public User createUserForBinding(String bindingId) {
+        String userName = getUserNameForBinding(bindingId);
+        logger.info("Creating user '{}' for service binding '{}'", userName, bindingId);
+        return createUser(userName);
+    }
+
+    public String getUserNameForBinding(String bindingId) {
+        return getUserNamePrefix() + bindingId;
+    }
+
+    /**
+     * The user must not be a member of any groups or have any access keys.
+     *
+     * @param bindingId
+     */
+    public void deleteUserForBinding(String bindingId) {
+        String userName = getUserNameForBinding(bindingId);
+        logger.info("Deleting user '{}' from service binding '{}'", userName, bindingId);
+        deleteUser(userName);
+    }
+
+    public void removeUserFromGroupForInstance(String bindingId, String instanceId) {
+        String userName = getUserNameForBinding(bindingId);
+        String groupName = getGroupNameForInstance(instanceId);
+        removeUserFromGroup(userName, groupName);
+    }
+
+    public void deleteUserAccessKeysForBinding(String bindingId) {
+        String userName = getUserNameForBinding(bindingId);
+        deleteUserAccessKeys(userName);
+    }
+}

--- a/src/main/java/org/cloudfoundry/community/servicebroker/s3/policy/BucketGroupPolicy.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/s3/policy/BucketGroupPolicy.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.cloudfoundry.community.servicebroker.s3.service;
+package org.cloudfoundry.community.servicebroker.s3.policy;
 
 /**
  * @author David Ehringer
@@ -25,7 +25,7 @@ public class BucketGroupPolicy {
     public BucketGroupPolicy(String policyDocument) {
         this.policyDocument = policyDocument;
     }
-    
+
     public String policyDocumentForBucket(String bucketName){
         return policyDocument.replace("${bucketName}", bucketName);
     }

--- a/src/main/java/org/cloudfoundry/community/servicebroker/s3/service/Iam.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/s3/service/Iam.java
@@ -15,6 +15,7 @@
  */
 package org.cloudfoundry.community.servicebroker.s3.service;
 
+import org.cloudfoundry.community.servicebroker.s3.policy.BucketGroupPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/org/cloudfoundry/community/servicebroker/ServiceBrokerV2IntegrationTestBase.java
+++ b/src/test/java/org/cloudfoundry/community/servicebroker/ServiceBrokerV2IntegrationTestBase.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.cloudfoundry.community.servicebroker;
 
 import com.jayway.restassured.RestAssured;

--- a/src/test/java/org/cloudfoundry/community/servicebroker/s3/S3ServiceBrokerV2IntegrationTests.java
+++ b/src/test/java/org/cloudfoundry/community/servicebroker/s3/S3ServiceBrokerV2IntegrationTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.cloudfoundry.community.servicebroker.s3;
 
 import com.amazonaws.auth.BasicAWSCredentials;


### PR DESCRIPTION
Because of some Amazon limitations ([100 buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html), [5000 IAM Users](http://docs.aws.amazon.com/IAM/latest/UserGuide/limits.html)), we at Mendix have been working on a "[Shared S3 Plan](https://github.com/mendix/s3-cf-service-broker/tree/shared-plan)", next to the Basic S3 Plan, where we share 1 bucket and 1 shared IAM account with all "Service Instances".

In preparation of the additional "Shared S3 Plan", in this Pull Request we've done some refactoring to add support for a new plan more easily, mainly:
- Iam.java has been split up in iam/Iam.java and iam/plan/BasicPlanIam.java
- service/S3ServiceInstanceService.java is now more generic, Basic Plan specific stuff moved to plan/BasicPlan.java
