### PR TITLE
Add uri and host credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ The credentials provided in a bind call have the following format:
 	"username":"cloud-foundry-s3-c5271ba4-6d2f-4163-843c-6a5fdceb7a1a",
 	"access_key_id":"secret",
 	"bucket":"cloud-foundry-2eac2d52-bfc9-4d0f-af28-c02187689d72",
-	"secret_access_key":"secret"
+	"secret_access_key":"secret",
+	"host":"s3.amazonaws.com",
+	"uri":"s3://secret:secret@s3.amazonaws.com/cloud-foundry-2eac2d52-bfc9-4d0f-af28-c02187689d72"
 }
 ```
 


### PR DESCRIPTION
It can be useful for auto-configuration in app to have the full bucket s3 uri in credentials.

Actually, it assumes that users will only use s3 bucket from aws but users could also want to move to another s3 compatible broker like [p-riakcs](http://docs.pivotal.io/p-riakcs).

This PR intends to uniform all s3 bucket to make auto-configuration easier.

This current broker is not eligible to the [s3 spring boot connectors](https://github.com/Orange-OpenSource/spring-cloud-s3-connectors) because there is no uri or/and no host set in credentials.

I think it's a good thing to always have an `uri` credential when it's possible in service broker mainly to uniform auto-configuration.
